### PR TITLE
ci: run unit tests on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,28 +1,33 @@
-name: Tests
+name: Unit Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: python -m pip install --upgrade setuptools pip wheel tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+          python -m pip install -e .
 
-      - name: Run tox
-        run: tox
+      - name: Run tests
+        run: tox -e py3


### PR DESCRIPTION
## Summary
- ensure unit tests run in GitHub Actions on pushes and pull requests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'lark')*


------
https://chatgpt.com/codex/tasks/task_e_68bdb58868c0832da2ed878c716cb6bc