### PR TITLE
Add test for comments in nested parentheses

### DIFF
--- a/tests/formatter/input-output-pairs/custom-comments-in-nested-parens.in.gd
+++ b/tests/formatter/input-output-pairs/custom-comments-in-nested-parens.in.gd
@@ -1,0 +1,15 @@
+func test(a, b, c) -> void:
+	var test_condition: bool = (
+		# Condition A
+		not really_really_really_really_really_really_long_func(a)
+		and (
+			# Condition B
+			really_really_really_really_really_really_long_func(b)
+			# Condition C
+			or really_really_really_really_really_really_long_func(c)
+		)
+	)
+
+
+func really_really_really_really_really_really_long_func(x) -> bool:
+	return x != null

--- a/tests/formatter/input-output-pairs/custom-comments-in-nested-parens.out.gd
+++ b/tests/formatter/input-output-pairs/custom-comments-in-nested-parens.out.gd
@@ -1,0 +1,15 @@
+func test(a, b, c) -> void:
+	var test_condition: bool = (
+		# Condition A
+		not really_really_really_really_really_really_long_func(a)
+		and (
+			# Condition B
+			really_really_really_really_really_really_long_func(b)
+			# Condition C
+			or really_really_really_really_really_really_long_func(c)
+		)
+	)
+
+
+func really_really_really_really_really_really_long_func(x) -> bool:
+	return x != null


### PR DESCRIPTION
## Summary
- add regression test ensuring comments inside nested parentheses are preserved

## Testing
- `pytest tests/formatter/test_input_output_pairs.py::test_input_output_pair -k custom-comments-in-nested-parens -vv` *(fails: ModuleNotFoundError: No module named 'lark')*
- `pre-commit run --files tests/formatter/input-output-pairs/custom-comments-in-nested-parens.in.gd tests/formatter/input-output-pairs/custom-comments-in-nested-parens.out.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c058b52548832db617ec6a81184215